### PR TITLE
Update configuration file

### DIFF
--- a/influxdb/files/influxdb.conf
+++ b/influxdb/files/influxdb.conf
@@ -315,7 +315,7 @@ reporting-disabled = false
 ###
 
 {%- if server.udp.enabled %}
-[udp]
+[[udp]]
   enabled = true
   bind-address = "{{ server.udp.bind.address }}:{{ server.udp.bind.port }}"
   # database = "udp"
@@ -340,7 +340,7 @@ reporting-disabled = false
   ]
   {%- endif %}
 {%- else %}
-[udp]
+[[udp]]
   enabled = false
 {%- endif %}
 

--- a/influxdb/files/influxdb.conf
+++ b/influxdb/files/influxdb.conf
@@ -102,20 +102,19 @@ reporting-disabled = false
 {%- endif %}
 
 ###
-### [cluster]
+### [coordinator]
 ###
-### Controls non-Raft cluster behavior, which generally includes how data is
-### shared across shards.
+### Controls the clustering service configuration.
 ###
 
-[cluster]
-  shard-writer-timeout = "5s" # The time within which a remote shard must respond to a write request.
-  write-timeout = "10s" # The time within which a write request must complete on the cluster.
-  max-concurrent-queries = 0 # The maximum number of concurrent queries that can run. 0 to disable.
-  query-timeout = "0s" # The time within a query must complete before being killed automatically. 0s to disable.
-  max-select-point = 0 # The maximum number of points to scan in a query. 0 to disable.
-  max-select-series = 0 # The maximum number of series to select in a query. 0 to disable.
-  max-select-buckets = 0 # The maximum number of buckets to select in an aggregate query. 0 to disable.
+[coordinator]
+  write-timeout = "10s"
+  max-concurrent-queries = 0
+  query-timeout = "0"
+  log-queries-after = "0"
+  max-select-point = 0
+  max-select-series = 0
+  max-select-buckets = 0
 
 ###
 ### [retention]

--- a/influxdb/files/influxdb.conf
+++ b/influxdb/files/influxdb.conf
@@ -212,6 +212,19 @@ reporting-disabled = false
 {%- endif %}
 
 ###
+### [subscriber]
+###
+### Controls the subscriptions, which can be used to fork a copy of all data
+### received by the InfluxDB host.
+###
+
+[subscriber]
+  enabled = false
+  # http-timeout = "30s"
+  # write-concurrency = 40
+  # write-buffer-size = 1000
+
+###
 ### [[graphite]]
 ###
 ### Controls one or many listeners for Graphite data.


### PR DESCRIPTION
The config file is for InfluxDB 1.0. It is not backward compatible because support for clustering has been removed from the open source version.
