### PR TITLE
Disable HTTP logs by default

### DIFF
--- a/influxdb/files/influxdb.conf
+++ b/influxdb/files/influxdb.conf
@@ -192,7 +192,7 @@ reporting-disabled = false
   {%- else %}
   auth-enabled = false
   {%- endif %}
-  log-enabled = true
+  log-enabled = {{ server.http.log_enabled | lower }}
   write-tracing = false
   pprof-enabled = false
   {%- if server.http.get('ssl', {}).get('enabled', False) %}

--- a/influxdb/map.jinja
+++ b/influxdb/map.jinja
@@ -10,6 +10,7 @@ default:
     bind:
       address: 0.0.0.0
       port: 8086
+    log_enabled: false
   udp:
     enabled: false
     bind:


### PR DESCRIPTION
Because they are too verbose and degrade the performances.