### PR TITLE
Remove influxdb cluster annotation in Grafana

### DIFF
--- a/influxdb/files/grafana_influxdb.json
+++ b/influxdb/files/grafana_influxdb.json
@@ -1,20 +1,6 @@
 {
   "annotations": {
-    "list": [
-      {
-        "datasource": "lma",
-        "enable": true,
-        "iconColor": "#C0C6BE",
-        "iconSize": 13,
-        "lineColor": "rgba(255, 96, 96, 0.592157)",
-        "name": "Status",
-        "query": "select title,tags,text from annotations where $timeFilter and cluster = 'influxdb'",
-        "showLine": true,
-        "tagsColumn": "tags",
-        "textColumn": "text",
-        "titleColumn": "title"
-      }
-    ]
+    "list": []
   },
   "editable": true,
   "gnetId": null,


### PR DESCRIPTION
There is no InfluxDB cluster, so this cluster-level annotation does not make sense.