### PR TITLE
Ensure custom paths are created and have correct permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Single-node influxdb, SSL for http frontend:
               key_file: /etc/influxdb/ssl/key.pem
               cert_file: /etc/influxdb/ssl/cert.pem
 
-Single-node influxdb where you specify paths for data and metastore directories. You
-need to ensure that directories exist:
+Single-node influxdb where you specify paths for data and metastore directories. Custom
+directories are created by this formula:
 
 .. code-block:: yaml
 

--- a/influxdb/map.jinja
+++ b/influxdb/map.jinja
@@ -3,6 +3,8 @@ default:
   pkgs:
   - influxdb
   service: influxdb
+  service_user: influxdb
+  service_group: influxdb
   container_mode: false
   prefix_dir: /
   reporting_disabled: true

--- a/influxdb/server.sls
+++ b/influxdb/server.sls
@@ -35,6 +35,27 @@ influxdb_default:
     - pkg: influxdb_packages
 {%- endif %}
 
+{{server.data.dir}}:
+  file.directory:
+    - makedirs: True
+    - mode: 755
+    - user: {{ server.service_user }}
+    - group: {{ server.service_group }}
+
+{{server.data.wal_dir}}:
+  file.directory:
+    - makedirs: True
+    - mode: 755
+    - user: {{ server.service_user }}
+    - group: {{ server.service_group }}
+
+{{server.meta.dir}}:
+  file.directory:
+    - makedirs: True
+    - mode: 755
+    - user: {{ server.service_user }}
+    - group: {{ server.service_group }}
+
 influxdb_service:
   service.running:
   - enable: true

--- a/tests/pillar/cluster.sls
+++ b/tests/pillar/cluster.sls
@@ -1,7 +1,11 @@
 influxdb:
   server:
     enabled: true
+    data:
+      dir: /opt/influxdb/data
+      wal_dir: /opt/influxdb/wal
     meta:
+      dir: /opt/influxdb/meta
       enabled: true
       bind:
         address: 0.0.0.0


### PR DESCRIPTION
In case you find useful. This was required for us in order to use influxdb in Ubuntu 16 with systemd. We need to store influxdb in a custom path where we have an additional EBS.