### PR TITLE
Drop the space between 'bind-addr=' and 'output ='

### DIFF
--- a/influxdb/files/influxdb-relay.conf
+++ b/influxdb/files/influxdb-relay.conf
@@ -45,7 +45,6 @@ read-buffer = {{ listen.read_buffer|int }}
   {%- endif %}
   {%- do outputs.append(tmp) %}
 {%- endfor %}
-
 output = [
 {%- for output in outputs %}
   { {{ output|join(', ') }} },

--- a/tests/pillar/repo_influxdata.sls
+++ b/tests/pillar/repo_influxdata.sls
@@ -3,7 +3,7 @@ linux:
     enabled: true
     repo:
       linux_influxdata:
-        source: "deb http://repos.influxdata.com/ubuntu {{ grains.get('oscodename') }} stable"
+        source: "deb http://repos.influxdata.com/{{ grains.get('os').lower() }} {{ grains.get('oscodename') }} stable"
         architectures: amd64
         # key_url: "http://repos.influxdata.com/influxdb.key"
         # https repo not working - see https://github.com/influxdata/influxdb/issues/9199 for more info


### PR DESCRIPTION
Causes "(Client.Timeout exceeded while awaiting headers)" from telegraf (1.8.0)